### PR TITLE
fix bug with colored pages

### DIFF
--- a/lib/src/main/res/layout/book_loading.xml
+++ b/lib/src/main/res/layout/book_loading.xml
@@ -7,5 +7,6 @@
 
     <com.victor.loading.book.BookView
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:background="@color/book_loading_page" />
 </FrameLayout>


### PR DESCRIPTION
In the book animation, if we give background and pages different colors, a visual bug becomes apparent. BookView should have the page color as background.