### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
 gradle
 
 ```
-compile 'com.victor:lib:1.0.4'
+implementation 'com.victor:lib:1.0.4'
 ```
 Xamarin.Android binding version [here](https://github.com/g0rdan/Xamarin.Android.LoadingViews)
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.